### PR TITLE
fix: unlock the core library dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
         "php": ">=8.0.0",
         "ext-json": "*",
         "nyholm/psr7": "^1.8",
-        "oat-sa/lib-lti1p3-core": "7.2.2", 
+        "oat-sa/lib-lti1p3-core": "^7.0",
         "psr/http-message": "^1.1 || ^2.0",
         "psr/http-server-handler": "^1.0",
         "symfony/dom-crawler": "^4.4 || ^5.1 || ^6.4 || ^7.1",


### PR DESCRIPTION
This PR fixes dependency mishap introduced in https://github.com/oat-sa/lib-lti1p3-basic-outcome/pull/36

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the version requirements for a dependency to allow for a broader range of compatible versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->